### PR TITLE
Yaml doc server

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,10 @@ validator.init(app, validatorOptions, format);
 where:
 
   - `app` is the Express app instance.
-  - `format` is an string to choose the format we want to create the swagger docs, jsdoc or yaml. Default jsdoc.
-  - `validatorOptions` is a configuration object like this: 
+  - `format` is an string to choose the format we want to create the swagger docs: `jsdoc` or `yaml`. Default `jsdoc`.
+  - `validatorOptions` is a configuration object that has different format depending on `format`:
+
+**`validatorOptions` for _jsdoc_**
 
 ```js
 const validatorOptions = {
@@ -56,6 +58,24 @@ const validatorOptions = {
     url: '/test/docs/api',
     docs: '/test/docs/api.json',
   },
+};
+```
+
+**`validatorOptions` for _yaml_**
+
+```js
+const validatorOptions = {
+  swaggerDefinition: {
+    info: {
+      description: 'Documentation for Service API',
+      title: 'Service API',
+      version: '1.0.0',
+      contact: { email: 'your_email@guidesmiths.com' },
+    },
+    basePath: '/',
+  },
+  apis: ['./test/**/**.js'], // paths to the API files
+  url: '/test/docs/api', // optional path to serve the API documentation
 };
 ```
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 const expressSwaggerGenerator = require('express-swagger-generator');
 const validator = require('swagger-model-validator');
 const swaggerJSDoc = require('swagger-jsdoc');
+const swaggerUi = require('swagger-ui-express');
 
 const errorFactory = require('./lib/errors');
 
@@ -31,14 +32,18 @@ const createInstance = (app, swaggerOptions, format) => {
 			const options = {
 				// Import swaggerDefinitions
 				swaggerDefinition,
-				// Path to the API docs
-				// Note that this path is relative to the current directory from which the Node.js is ran, not the application itself.
 				...rest,
 			};
 
 			// Initialize swagger-jsdoc -> returns validated swagger spec in json format
 			const swaggerSpec = swaggerJSDoc(options);
 			const swaggerInstance = validator(swaggerSpec);
+
+			// If a URL is included in the configuration, serve the API doc through it
+			if (rest.url) {
+				app.use(rest.url, swaggerUi.serve, swaggerUi.setup(swaggerSpec));
+			}
+
 			return swaggerInstance.swagger;
 		},
 	};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-endpoint-validator",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -6058,6 +6058,19 @@
       "version": "2.0.0-bab6bed",
       "resolved": "https://registry.npmjs.org/swagger-schema-official/-/swagger-schema-official-2.0.0-bab6bed.tgz",
       "integrity": "sha1-cAcEaNbSl3ylI3suUZyn0Gouo/0="
+    },
+    "swagger-ui-dist": {
+      "version": "3.24.3",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.24.3.tgz",
+      "integrity": "sha512-kB8qobP42Xazaym7sD9g5mZuRL4416VIIYZMqPEIskkzKqbPLQGEiHA3ga31bdzyzFLgr6Z797+6X1Am6zYpbg=="
+    },
+    "swagger-ui-express": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.1.2.tgz",
+      "integrity": "sha512-bVT16qj6WdNlEKFkSLOoTeGuqEm2lfOFRq6mVHAx+viA/ikORE+n4CS3WpVcYmQzM4HE6+DUFgAWcMRBJNpjcw==",
+      "requires": {
+        "swagger-ui-dist": "^3.18.1"
+      }
     },
     "symbol-tree": {
       "version": "3.2.4",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   "dependencies": {
     "express-swagger-generator": "^1.1.15",
     "swagger-jsdoc": "^3.5.0",
-    "swagger-model-validator": "^3.0.12"
+    "swagger-model-validator": "^3.0.12",
+    "swagger-ui-express": "^4.1.2"
   },
   "devDependencies": {
     "eslint": "^6.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-endpoint-validator",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A validator of API endpoints to check that input and output match with the swagger specification for the API",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
When documenting with YAML format, the libraries used are different, so no documentation was generated to be served through a URL.

This PR adds support to do that if the user adds a `url` attribute to the configuration.