### PR TITLE
docs: fix url to repo in the docsify page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -14,7 +14,7 @@
     window.$docsify = {
       name: 'swagger-endpoint-validator',
       themeColor: '#17ae8e',
-      repo: 'git@github.com:guidesmiths/swagger-endpoint-validator'
+      repo: 'guidesmiths/swagger-endpoint-validator'
     }
   </script>
   <script src="//unpkg.com/docsify/lib/docsify.min.js"></script>


### PR DESCRIPTION
The URL included at the top right side of the `docsify` generated page was wrong: it linked to a non-existant address rather than to the actual repository. That issue has now been solved by adding the right value to the `repo` property in the settings. Therefore, this PR should close #20.