### PR TITLE
chore(deps): bump express-jsdoc-swagger from 1.0.4 to 1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1122,7 +1122,8 @@
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
-      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
+      "dev": true
     },
     "@types/graceful-fs": {
       "version": "4.1.3",
@@ -2938,9 +2939,9 @@
       }
     },
     "express-jsdoc-swagger": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/express-jsdoc-swagger/-/express-jsdoc-swagger-1.0.4.tgz",
-      "integrity": "sha512-+D04u9jnSyEytfr6/gsGQgHtf8NgDgE91BLkzSZgDG/qsTbzu9hxANUdShiIZt3Sexkd7g7O9lcKrMo1NT4xTA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/express-jsdoc-swagger/-/express-jsdoc-swagger-1.1.0.tgz",
+      "integrity": "sha512-vAZx4fOUoS7nr0IiWg9FlzfxiZBUQoC95sIGYEFalWi1vz2mSUY23rCwD5hhqzi5msehBRtUwFNOQGeP5aj3Dw==",
       "requires": {
         "chalk": "^4.1.0",
         "doctrine": "^3.0.0",
@@ -2951,11 +2952,10 @@
       },
       "dependencies": {
         "ansi-styles": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "requires": {
-            "@types/color-name": "^1.1.1",
             "color-convert": "^2.0.1"
           }
         },
@@ -2987,9 +2987,9 @@
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
         },
         "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "requires": {
             "has-flag": "^4.0.0"
           }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-endpoint-validator",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "A validator of API endpoints to check that input and output match with the swagger specification for the API",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "homepage": "https://github.com/guidesmiths/swagger-endpoint-validator#readme",
   "dependencies": {
     "debug": "^4.1.1",
-    "express-jsdoc-swagger": "^1.0.4",
+    "express-jsdoc-swagger": "^1.1.0",
     "express-openapi-validator": "^3.12.7",
     "js-yaml": "^3.14.0",
     "openapi-enforcer": "^1.10.3",


### PR DESCRIPTION
This PR updates express-jsdoc-swagger dependency to the last one.